### PR TITLE
Fix typos and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Applied LaTeX for Researchers
 
-This repository holds the materials for the LaTeX workshop (March 7th, 2025). 
+This repository holds the materials for the LaTeX workshop (March 7th, 2025).
+
+## Building the Examples
+
+The source files for the workshop are located in `scripts/` and `slides/`.
+To compile them into PDFs you can run:
+
+```bash
+pdflatex scripts/main.tex
+pdflatex slides/latex_lecture.tex
+```
+
+Ensure that a LaTeX distribution such as TeX&nbsp;Live is installed before running these commands.

--- a/scripts/main.tex
+++ b/scripts/main.tex
@@ -61,7 +61,7 @@ This is a list.
 
 % never forget to use the percentage function if you actually want to write a percentage in-text. 
 
-GDP increased by 10\% and also inflation rised by 5\%.
+GDP increased by 10\% and inflation rose by 5\%.
 
 \textbackslash
 
@@ -108,7 +108,7 @@ Rules of math mode:
 
 This is a line. It has math in it. $x + 1 = 2$
 
-There is another line without math $$x + 1 = 2$$
+This is another line with display math $$x + 1 = 2$$
 
 The equation environment:
 

--- a/slides/latex_lecture.tex
+++ b/slides/latex_lecture.tex
@@ -12,7 +12,8 @@
 \useinnertheme{rounded}
 \definecolor{darkergreen}{rgb}{0.12, 0.3, 0.17}
 \definecolor{lapislazuli}{rgb}{0.15, 0.38, 0.61}
-\definecolor{veige}{rgb}{0.12,,215}
+% Define a beige color used for some highlights
+\definecolor{beige}{rgb}{0.96, 0.96, 0.86}
 \definecolor{black}{rgb}{0,0,0}
 \definecolor{burlywood}{rgb}{0.87, 0.72, 0.53}
 \setbeamercolor{background canvas}{bg=white}
@@ -246,7 +247,7 @@
 \begin{frame}{Why math mode?}
     \begin{itemize}
         \item \LaTeX's math mode is where it truly shines.
-        \item This synthax has become a standard for typesetting math, even beyond \LaTeX.
+        \item This syntax has become a standard for typesetting math, even beyond \LaTeX.
         \item While Microsoft Word's equation editor has come a long way, when things get complex, \LaTeX \ is the way to go
         \begin{itemize}
             \item Aligning equations
@@ -376,7 +377,7 @@
     \begin{itemize}
         \item Manually creating the \texttt{tabular} environment can be tedious.
         \item Check out online tools such as the Overleaf tables editor or \href{tablesgenerator.com}{tablesgenerator.com}.
-        \item The Excel addin, Excel2LaTeX, can be used to convert Excel tables to \LaTeX, \href{https://github.com/ivankokan/Excel2LaTeX/releases/tag/v3.5.0}{download here}.
+        \item The Excel add-in, Excel2LaTeX, can be used to convert Excel tables to \LaTeX, \href{https://github.com/ivankokan/Excel2LaTeX/releases/tag/v3.5.0}{download here}.
     \end{itemize}
 \end{frame}
 


### PR DESCRIPTION
## Summary
- fix invalid color definition in slides
- correct spelling of "syntax" and update table slide text
- fix grammar in `scripts/main.tex`
- clarify display math comment
- add build instructions in the README
- ensure newline at end of slides file

## Testing
- `pdflatex -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686a94a325f8832d8a67737fc8caaff5